### PR TITLE
Tighten up types for Result

### DIFF
--- a/specs/result.spec.ts
+++ b/specs/result.spec.ts
@@ -1,8 +1,9 @@
-import { Ok, Err } from '../src/result'
+import { Ok, Err, Result } from '../src/result'
 
 describe('Result', () => {
 
-  const person = { name: 'jason', age: 4 }
+  type Person = { name: string, age: number }
+  const person: Person = { name: 'jason', age: 4 }
 
   it('should have map', done => {
     Ok(person)
@@ -48,6 +49,28 @@ describe('Result', () => {
         Err: done.fail
       })
 
+    done()
+  })
+
+  it('should be instantiable without arguments', done => {
+    Ok()
+      .map(() => person)
+      .cata({
+        Ok: p => expect(p).toBe(person),
+        Err: done.fail
+      })
+    done()
+  })
+
+  it("when instantiated with a defined value, callbacks don't need to check against undefined", done => {
+
+    Ok(person)
+      .map((p: Person): string => p.name)
+      .chain((name: string): Result<string, string> => name === 'jason' ? Ok(name) : Err('Name not jason'))
+      .cata({
+        Ok: name => expect(name).toBe('jason'),
+        Err: done.fail
+      })
     done()
   })
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -2,30 +2,31 @@ import { Maybe, nullable, Nothing } from './maybe'
 
 export type Result<O, E> = {
   ap: <A>(r: Result<A, E>) => Result<A, E>
-  map: <A>(cb: (arg?: O) => A) => Result<A, E>
-  mapErr: <A>(cb: (arg?: E) => A) => Result<O, A>
-  chain: <A>(cb: (arg?: O) => Result<A, E>) => Result<A, E>
-  chainErr: <A>(cb: (arg?: E) => Result<O, A>) => Result<O, A>
+  map: <A>(cb: (arg: O) => A) => Result<A, E>
+  mapErr: <A>(cb: (arg: E) => A) => Result<O, A>
+  chain: <A>(cb: (arg: O) => Result<A, E>) => Result<A, E>
+  chainErr: <A>(cb: (arg: E) => Result<O, A>) => Result<O, A>
   swap: () => Result<O, E>
-  bimap: <A, B>(ok: (arg?: O) => A, err: (arg?: E) => B) => Result<A, B>
+  bimap: <A, B>(ok: (arg: O) => A, err: (arg: E) => B) => Result<A, B>
   cata: <A, B>(obj: {
-    Ok: (arg?: O) => A
-    Err: (arg?: E) => B
-  }) => A|B
+    Ok: (arg: O) => A
+    Err: (arg: E) => B
+  }) => A | B
   toMaybe: () => Maybe<O>
   inspect: () => string
   isErr: () => boolean
   isOk: () => boolean
 }
 
-export const Ok = <O>(arg?: O): Result<O, any> => ({
+
+const innerOk = <O>(arg: O): Result<O, any> => ({
   ap: <A>(r: Result<A, any>) => typeof arg === 'function' ? r.map(x => arg(x)) : Err(),
-  map: <A>(cb: (a?: O) => A): Result<A, any> => Ok(cb(arg)),
-  mapErr: (): Result<O, any> => Ok(arg),
-  chain: <A>(cb: (a?: O) => Result<A, any>): Result<A, any> => cb(arg),
-  chainErr: () => Ok(arg),
-  swap: () => Err(arg),
-  bimap: (ok, _) => Ok(ok(arg)),
+  map: <A>(cb: (a: O) => A): Result<A, any> => innerOk(cb(arg)),
+  mapErr: (): Result<O, any> => innerOk(arg),
+  chain: <A>(cb: (a: O) => Result<A, any>): Result<A, any> => cb(arg),
+  chainErr: () => innerOk(arg),
+  swap: () => innerErr(arg),
+  bimap: (ok, _) => innerOk(ok(arg)),
   cata: obj => obj.Ok(arg),
   toMaybe: () => nullable(arg),
   inspect: () => `Ok(${arg})`,
@@ -33,17 +34,29 @@ export const Ok = <O>(arg?: O): Result<O, any> => ({
   isOk: () => true
 })
 
-export const Err = <E>(arg?: E): Result<any, E> => ({
-  ap: () => Err(arg),
-  map: () => Err(arg),
-  mapErr: <A>(cb: (a?: E) => A): Result<any, A> => Err(cb(arg)),
-  chain: () => Err(arg),
+const innerErr = <E>(arg: E): Result<any, E> => ({
+  ap: () => innerErr(arg),
+  map: () => innerErr(arg),
+  mapErr: <A>(cb: (a: E) => A): Result<any, A> => innerErr(cb(arg)),
+  chain: () => innerErr(arg),
   chainErr: cb => cb(arg),
-  swap: () => Ok(arg),
-  bimap: (_, err) => Err(err(arg)),
+  swap: () => innerOk(arg),
+  bimap: (_, err) => innerErr(err(arg)),
   cata: obj => obj.Err(arg),
   toMaybe: () => Nothing,
   inspect: () => `Err(${arg})`,
   isErr: () => true,
   isOk: () => false
 })
+
+export function Ok(): Result<any, any>
+export function Ok<O>(arg: O): Result<O, any>
+export function Ok<O>(arg?: O): Result<O | undefined, any> {
+  return innerOk(arg)
+}
+
+export function Err(): Result<any, any>
+export function Err<E>(arg: E): Result<any, E>
+export function Err<E>(arg?: E): Result<any, E | undefined> {
+  return innerErr(arg)
+}

--- a/src/result.ts
+++ b/src/result.ts
@@ -19,14 +19,14 @@ export type Result<O, E> = {
 }
 
 
-const innerOk = <O>(arg: O): Result<O, any> => ({
+const _Ok = <O>(arg: O): Result<O, any> => ({
   ap: <A>(r: Result<A, any>) => typeof arg === 'function' ? r.map(x => arg(x)) : Err(),
-  map: <A>(cb: (a: O) => A): Result<A, any> => innerOk(cb(arg)),
-  mapErr: (): Result<O, any> => innerOk(arg),
+  map: <A>(cb: (a: O) => A): Result<A, any> => _Ok(cb(arg)),
+  mapErr: (): Result<O, any> => _Ok(arg),
   chain: <A>(cb: (a: O) => Result<A, any>): Result<A, any> => cb(arg),
-  chainErr: () => innerOk(arg),
-  swap: () => innerErr(arg),
-  bimap: (ok, _) => innerOk(ok(arg)),
+  chainErr: () => _Ok(arg),
+  swap: () => _Err(arg),
+  bimap: (ok, _) => _Ok(ok(arg)),
   cata: obj => obj.Ok(arg),
   toMaybe: () => nullable(arg),
   inspect: () => `Ok(${arg})`,
@@ -34,14 +34,14 @@ const innerOk = <O>(arg: O): Result<O, any> => ({
   isOk: () => true
 })
 
-const innerErr = <E>(arg: E): Result<any, E> => ({
-  ap: () => innerErr(arg),
-  map: () => innerErr(arg),
-  mapErr: <A>(cb: (a: E) => A): Result<any, A> => innerErr(cb(arg)),
-  chain: () => innerErr(arg),
+const _Err = <E>(arg: E): Result<any, E> => ({
+  ap: () => _Err(arg),
+  map: () => _Err(arg),
+  mapErr: <A>(cb: (a: E) => A): Result<any, A> => _Err(cb(arg)),
+  chain: () => _Err(arg),
   chainErr: cb => cb(arg),
-  swap: () => innerOk(arg),
-  bimap: (_, err) => innerErr(err(arg)),
+  swap: () => _Ok(arg),
+  bimap: (_, err) => _Err(err(arg)),
   cata: obj => obj.Err(arg),
   toMaybe: () => Nothing,
   inspect: () => `Err(${arg})`,
@@ -52,11 +52,11 @@ const innerErr = <E>(arg: E): Result<any, E> => ({
 export function Ok(): Result<any, any>
 export function Ok<O>(arg: O): Result<O, any>
 export function Ok<O>(arg?: O): Result<O | undefined, any> {
-  return innerOk(arg)
+  return _Ok(arg)
 }
 
 export function Err(): Result<any, any>
 export function Err<E>(arg: E): Result<any, E>
 export function Err<E>(arg?: E): Result<any, E | undefined> {
-  return innerErr(arg)
+  return _Err(arg)
 }


### PR DESCRIPTION
It can be irritating to initialize an `Ok` with some definitely-defined `O`, just to have to handle `O|undefined` in later `map` and `chain` callbacks. This change solves that problem without losing the ability to instantiate `Ok` and `Err` without parameters.

I don't expect this to break any clients, so please let me know if you think otherwise.