### PR TITLE
Added ESM Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This document outlines the changes from version to version.
 
+## 2.2.0
+
+- Added ESM support
+
 ## 2.1.1
 
 - Added `Result.value()`

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "pratica",
-  "module": "pratica",
   "version": "2.1.1",
   "description": "Functional Programming for Pragmatists",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "author": "Jason Rametta",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pratica",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Functional Programming for Pragmatists",
   "main": "dist/index.cjs",
   "module": "dist/index.esm.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,21 @@
 import typescript from 'rollup-plugin-typescript2'
+import { RollupOptions } from "rollup";
 
+/** @type {RollupOptions} */
 export default {
   input: 'src/index.ts',
-  output: {
-    name: 'pratica',
-    format: 'cjs',
-    file: 'dist/index.js'
-  },
+  output: [
+    {
+      name: 'pratica',
+      format: 'cjs',
+      file: 'dist/index.cjs'
+    },
+    {
+      name: 'pratica',
+      format: 'es',
+      file: 'dist/index.esm.js'
+    }
+  ],
   plugins: [
     typescript({
       typescript: require('typescript'),


### PR DESCRIPTION
# Added ESM Output

Added rollup output option to output ES module format. Can now be used with bundlers like vite!

Resolves #8 

<!-- Please check all the boxes with [x] -->

- [x] ~I have added or updated unit tests for this change.~ No tests needed
- [x] I have updated the [changelog](https://github.com/mr-josh/pratica/blob/main/CHANGELOG.md) with info about the changes in this PR
