### PR TITLE
Improve types of Result.{isOk, isErr, value}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This document outlines the changes from version to version.
 
+## 2.2.1
+
+- make `Result.isOk()` and `Result.isErr()` narrow the type of `Result.value()`
+
 ## 2.2.0
 
 - Added ESM support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pratica",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Functional Programming for Pragmatists",
   "main": "dist/index.cjs",
   "module": "dist/index.esm.js",

--- a/src/result.ts
+++ b/src/result.ts
@@ -14,10 +14,19 @@ export type Result<O, E> = {
   }) => A | B
   toMaybe: () => Maybe<O>
   inspect: () => string
-  isErr: () => boolean
-  isOk: () => boolean,
-  value: () => O | E
-}
+  // @ts-expect-error TS complains but this does work, https://github.com/microsoft/TypeScript/issues/51948
+  isErr: () => this is {__type: "Err"}
+  // @ts-expect-error TS complains but this does work, https://github.com/microsoft/TypeScript/issues/51948
+  isOk: () => this is {__type: "Ok"}
+} & ({
+  /** @deprecated This is for type magic, do not use */
+  __type: "Ok";
+  value: () => O;
+} | {
+  /** @deprecated This is for type magic, do not use */
+   __type: "Err";
+  value: () => E;
+});
 
 
 const _Ok = <O>(arg: O): Result<O, any> => ({
@@ -33,7 +42,8 @@ const _Ok = <O>(arg: O): Result<O, any> => ({
   inspect: () => `Ok(${arg})`,
   isErr: () => false,
   isOk: () => true,
-  value: () => arg
+  value: () => arg,
+  __type: "Ok"
 })
 
 const _Err = <E>(arg: E): Result<any, E> => ({
@@ -49,7 +59,8 @@ const _Err = <E>(arg: E): Result<any, E> => ({
   inspect: () => `Err(${arg})`,
   isErr: () => true,
   isOk: () => false,
-  value: () => arg
+  value: () => arg,
+  __type: "Err"
 })
 
 export function Ok(): Result<any, any>


### PR DESCRIPTION
# Improve types of Result.{isOk, isErr, value}

This improves type narrowing as shown below:

```ts
const x = {} as unknown as Result<string, number>;

const y = x.value(); // string | number

if (x.isOk()) {
  const y = x.value(); // string
} else {
  const y = x.value(); // number
}

if (x.isErr()) {
  const y = x.value(); // number
} else {
  const y = x.value(); // string
}
```

<!-- Please check all the boxes with [x] -->

- [x] I have added or updated unit tests for this change. (N/A)
- [x] I have updated the [changelog](https://github.com/rametta/pratica/blob/master/CHANGELOG.md) with info about the changes in this PR
